### PR TITLE
Invoke Media Modal on Term Edit Screens

### DIFF
--- a/assets/js/term-image.js
+++ b/assets/js/term-image.js
@@ -22,6 +22,15 @@ jQuery( document ).ready( function( $ ) {
 	$( '#addtag' ).on( 'click', '.wp-term-images-media', function ( event ) {
 		wp_term_images_show_media_modal( this, event );
 	} );
+	
+	/**
+	 * Invoke the media modal
+	 *
+	 * @param {object} event The event
+	 */
+	$( '#edittag' ).on( 'click', '.wp-term-images-media', function ( event ) {
+		wp_term_images_show_media_modal( this, event );
+	} );
 
 	/**
 	 * Remove image


### PR DESCRIPTION
During the "Make Quick Edits Great Again" change, you neglected to assess everything that would happen when you asked the `#addtag` and `#the-list` elements to pay for it. By leaving out the `#edittag` and it's click handler friends, you have isolated yourself from the rest of term edit screens.

I've brought `#edittag` into the fold so that way you're winning again with term meta images for existing terms. Your plugin is no longer a mess.

/trump-esque speech patterns

Just to recap for normal people, the "Choose Image" button on `term.php` wasn't working. This patch fixes it.
