### PR TITLE
Move the event listener for `.wp-term-images-media` so term media can be edited

### DIFF
--- a/assets/js/term-image.js
+++ b/assets/js/term-image.js
@@ -10,7 +10,7 @@ jQuery( document ).ready( function( $ ) {
 	 *
 	 * @param {object} event The event
 	 */
-	$( '#the-list' ).on( 'click', '.wp-term-images-media', function ( event ) {
+	$( '#wpbody-content' ).on( 'click', '.wp-term-images-media', function ( event ) {
 		wp_term_images_show_media_modal( this, event );
 	} );
 


### PR DESCRIPTION
When running version 0.3.0, the "Add Image" button works as expected on edit-tags.php (the list of taxonomy terms), but does nothing on term.php (the term edit screen).

This PR moves the `.wp-term-images-media` click handler from `#the-list` to `#wpbody-content`, and element higher in the DOM that's common across both pages.
