### PR TITLE
Clear the term image field from `#addtag` after the form is submitted

### DIFF
--- a/assets/js/term-image.js
+++ b/assets/js/term-image.js
@@ -42,6 +42,24 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	/**
+	 * Reset the form on submit.
+	 *
+	 * Since the form is never *actually* submitted (but instead serialized on #submit
+	 * being clicked), we'll have to do the same.
+	 *
+	 * @see wp-admin/js/tags.js
+	 *
+	 * @param {object} event The event.
+	 */
+	$('#submit').on( 'click', function ( event ) {
+		var self = $( this );
+
+		if ( 'addtag' === self.parents( 'form' ).attr( 'id' ) ) {
+			wp_term_images_reset( this, event );
+		}
+	} );
+
+	/**
 	 * Quick edit interactions
 	 */
     $( '#the-list' ).on( 'click', 'a.editinline', function() {


### PR DESCRIPTION
When a new term is created, every field _except_ for the term image is cleared from `form#addtag`.

This PR adds a handler to the `#submit` button (since [WordPress core doesn't actually submit the form](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/js/tags.js#L31)) that – as long as the parent form is `#addtag` – will clear the WP Term Image fields when a new term is created.
